### PR TITLE
Update README usage example with correct module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ and use them as:
 package main
 
 import (
-    "github.com/nutanix/ntnx-api-golang-client/vmm-go-client/v4/client"
+    "github.com/nutanix/ntnx-api-golang-clients/vmm-go-client/v4/client"
 )
 var (
     ApiClientInstance *client.ApiClient


### PR DESCRIPTION
This PR updates the module path in the README's usage example to reflect the correct repository name. 
The previous module path referenced `ntnx-api-golang-client`, which has been updated to `ntnx-api-golang-clients` in the repository. 
This ensures the documentation is accurate and prevents confusion for users following the usage instructions.